### PR TITLE
Add notebook on k-means

### DIFF
--- a/liesse/4-Supplements.ipynb
+++ b/liesse/4-Supplements.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "0a9f799e",
    "metadata": {},
    "source": [
     "# Stage LIESSE – Suppléments"
@@ -10,7 +9,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "783bf82f",
    "metadata": {},
    "source": [
     "Le but de ce notebook est de présenter quelques exemples supplémentaires d'utilisation de scikit-learn"
@@ -18,7 +16,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10448182",
    "metadata": {},
    "source": [
     "## Chargement des librairies"
@@ -27,7 +24,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e3f12d13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,7 +33,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "646e2130",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -48,7 +43,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "97e4389c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,7 +51,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d5959500",
    "metadata": {},
    "source": [
     "## Un exemple de surapprentissage\n",
@@ -68,7 +61,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bbd65e50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -81,7 +73,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1ae2e4fb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -93,7 +84,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "05419e62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -108,7 +98,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aec586bf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -122,7 +111,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "217fe2cf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -135,7 +123,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7a6483b9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -146,7 +133,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a958c2a0",
    "metadata": {},
    "source": [
     "Le modèle ne fait aucune erreur sur le jeu d'entraînement."
@@ -155,7 +141,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cfbf5305",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -165,7 +150,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c73cd9c9",
    "metadata": {},
    "source": [
     "Le modèle fait des erreurs sur le jeu de test."
@@ -173,7 +157,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2b2414bb",
    "metadata": {},
    "source": [
     "## Un exemple de classification multiclasse\n",
@@ -184,7 +167,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ba68ebe5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -195,7 +177,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9e85d0cf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -206,7 +187,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5c604e5e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -222,7 +202,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "df82c1a1",
    "metadata": {},
    "source": [
     "__Commentaire :__  Les données semblent assez bien séparées !"
@@ -231,7 +210,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6da98785",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -243,7 +221,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fa1c13f7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -256,7 +233,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31f703c0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -268,7 +244,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43c24776",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -279,7 +254,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4a7485b9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -290,7 +264,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b22c8438",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -301,7 +274,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f8364e97",
    "metadata": {},
    "source": [
     "__Pour aller plus loin :__ En reprenant le code du notebook 3, optimisez la valeur du nombre de voisins."
@@ -309,7 +281,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "576c7758",
    "metadata": {},
    "source": [
     "## Un exemple de traitement des chiffres manuscrits\n",
@@ -320,7 +291,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "afe28278",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -331,7 +301,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f57aaeba",
    "metadata": {},
    "source": [
     "`digits.images` contient les observations sous formes d'images 8 pixels x 8 pixels. Chaque pixel est représenté par un nombre entre 0 et 255 correspondant à son niveau de gris. On peut les visualiser ainsi :"
@@ -340,7 +309,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "83a4a934",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -351,7 +319,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5cd2c3be",
    "metadata": {},
    "source": [
     "`digits.data` contient les observations sous formes de vecteurs de taille 64 : on a mis bout à bout tous les pixels. On peut les visualiser aussi :"
@@ -360,7 +327,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cdcd64fc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -372,7 +338,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "288f6f05",
    "metadata": {},
    "source": [
     "`digits.target` contient les étiquettes :"
@@ -381,7 +346,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3255c471",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -391,7 +355,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8b048d36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -401,7 +364,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9872bd79",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -413,7 +375,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9bf57730",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -426,7 +387,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eb784fbd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -434,14 +394,6 @@
     "from sklearn import metrics\n",
     "metrics.plot_confusion_matrix(knnclass, X_test, y_test)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6d19c34c",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -460,9 +412,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.4"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 5
+ "nbformat_minor": 4
 }

--- a/liesse/5-Clustering.ipynb
+++ b/liesse/5-Clustering.ipynb
@@ -1,0 +1,738 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Stage LIESSE: Introduction au clustering avec K-means"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__Note:__ Ce notebook est inspiré des notebooks \n",
+    "- https://github.com/Henley13/teaching_td_clustering_2020/blob/main/tp5_clustering_solution.ipynb et \n",
+    "- https://jonchar.net/notebooks/k-means/,\n",
+    "- ainsi que de l'aide de scikit-learn : https://scikit-learn.org/stable/auto_examples/cluster/plot_kmeans_assumptions.html#sphx-glr-auto-examples-cluster-plot-kmeans-assumptions-py et https://scikit-learn.org/stable/auto_examples/cluster/plot_kmeans_assumptions.html#sphx-glr-auto-examples-cluster-plot-kmeans-assumptions-py."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Chargement des librairies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pylab inline \n",
+    "from IPython.display import set_matplotlib_formats\n",
+    "set_matplotlib_formats('svg')\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Définition de K-means"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "K-means est une méthode de clustering, c'est-à-dire qu'elle a pour but de partitionner les données en différents groupes homogènes, appelés cluster. Contrairement à la classification, le clustering ne dispose pas de labels (mâle/femelle dans les notebooks précédents), mais uniquement des variables.\n",
+    "\n",
+    "Il s'agit ainsi d'un méthode d'apprentissage non-supervisé : l'on n'a pas de label pour nous guider, et l'on essaye d'obtenir de l'information sur la \"forme\" de notre jeu de donnée (le mot *forme* étant compris dans un sens large et à définir)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "K-means partitionne notre jeu de donnée $(\\boldsymbol{x}_1, ..., \\boldsymbol{x}_n)$ en $k$ clusters $(C_1, ..., c_k)$ qui minimisent somme des variance intra-clusters, c'est-à-dire, tels que\n",
+    "\n",
+    "$$ \\sum_{j = 1}^k \\sum_{\\boldsymbol{x}_i\\in C_j} ||\\boldsymbol{x}_i - \\boldsymbol{\\mu}_j||^2$$\n",
+    "\n",
+    "soit minimal, sachant the le *centroide* $\\boldsymbol{\\mu_j}$ est la moyenne des points appartenant au cluster $C_i$.\n",
+    "\n",
+    "K-means est une méthode itérative pour trouver ces clusters. On initialise les centroides et on modifie les clusters de la manière itérative suivante :\n",
+    "\n",
+    "1. Assigner chaque point au cluster dont le centroide est le plus proche : $$C_j \\gets \\{\\boldsymbol{x}_i | \\forall j' \\neq j, ||\\boldsymbol{x}_i - \\boldsymbol{\\mu}_j||^2 \\leq ||\\boldsymbol{x}_i - \\boldsymbol{\\mu}_{j'}||^2\\}$$\n",
+    "\n",
+    "\n",
+    "2. Recalculer chaque centroide comme la moyenne des points de son cluster: $$\\mu_j \\gets \\frac{1}{|C_j|}\\sum_{\\boldsymbol{x}_i \\in C_j} \\boldsymbol{x}_i$$\n",
+    "\n",
+    "L'algorithme s'arrête quand l'assignement des clusters ne change pas d'une itération à l'autre. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__Quelques remarques sur K-means:__ \n",
+    "1. L'algorithme dépend des centroides choisis à l'initialisation et peut rester dans un optimum local : il n'y a pas de garantie que k-means trouve les clusters optimaux. En pratique, on peut lancer l'algorithme K-means avec différents centroids initiaux, et choisir un clustering parmi les différents qu'on obtient.\n",
+    "2. K-means associe tous les points les plus proches d'un centroide au cluster équivalent. Par conséquent, les clusters sont définis par le diagramme de Voronoi ([https://fr.wikipedia.org/wiki/Diagramme_de_Vorono%C3%AF](définition) et [https://scikit-learn.org/stable/auto_examples/cluster/plot_kmeans_digits.html#sphx-glr-auto-examples-cluster-plot-kmeans-digits-py](illustration sur scikit-learn)). Implicitement, K-means fait donc l'hypothèse que les clusters convexes, et ne marchera bien que si cette hypothèse est vérifiée.\n",
+    "3. K-means fait aussi l'hypothèse que tous les clusters sont isotropes (c'est-à-dire identiques dans toutes les directions) et ont même variance. [https://scikit-learn.org/stable/auto_examples/cluster/plot_kmeans_assumptions.html#sphx-glr-auto-examples-cluster-plot-kmeans-assumptions-py](Cet exemple) illustre les problèmes qui interviennes lorsque ces hypothèses ne sont pas vérifiées."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### K-means avec scikit-learn"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Sur les données réelles `penguins`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Nous allons illuster K-means sur des données réelles."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "penguins = pd.read_csv(\"data/penguins.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Extraire la matrice X et le vecteur y\n",
+    "X = penguins[[\"bill_length_mm\", \"bill_depth_mm\"]].to_numpy()\n",
+    "y = pd.Categorical(penguins[\"species\"]).astype('category').codes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn import cluster"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y_pred = cluster.KMeans(n_clusters=3, random_state=34).fit_predict(X)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "On peut représenter les clusters appris par K-means:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize = (8, 4))\n",
+    "\n",
+    "plt.subplot(121)\n",
+    "for label in [0, 1, 2]:\n",
+    "    plt.scatter(X[y_pred == label, 0], X[y_pred == label, 1], label=label)\n",
+    "plt.title(\"Clustering avec K-means (k = 3)\")\n",
+    "plt.xlabel(\"Longueur du bec (mm)\")\n",
+    "plt.ylabel(\"Hauteur du bec (mm)\")\n",
+    "plt.legend()\n",
+    "\n",
+    "plt.subplot(122)\n",
+    "for i, label in enumerate(list(set(penguins.loc[:, \"species\"]))):\n",
+    "    data_label = X[penguins.loc[:, \"species\"] == label, :]\n",
+    "    plt.scatter(data_label[:, 0], data_label[:, 1],\n",
+    "                s=30, label=label)\n",
+    "plt.title(\"Espèces de manchot\")\n",
+    "plt.xlabel(\"Longueur du bec (mm)\")\n",
+    "plt.ylabel(\"Hauteur du bec (mm)\")\n",
+    "plt.legend()\n",
+    "plt.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "K-means ne parvient pas à choisir des clusters qui correspondent aux trois espèces."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Sur données simulées"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Nous allons définir un jeu de données simulées que nous utiliserons pour le reste du notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn import datasets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Nous générons des données à partir d'un mélange de trois distributions gaussiennes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_samples = 1500\n",
+    "X, label = datasets.make_blobs(n_samples=n_samples, \n",
+    "                                  cluster_std=[1.0, 2.5, 0.5], \n",
+    "                                  random_state=170)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "On représente ces données:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_blobs = pd.DataFrame({\"x1\": X[:, 0],\n",
+    "                         \"x2\": X[:, 1],\n",
+    "                         \"label\": label})\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(5, 5))\n",
+    "for i in [0, 1, 2]:\n",
+    "    plt.scatter(X[label == i, 0], X[label == i, 1], label = i)\n",
+    "plt.xlabel(\"$x_1$\")\n",
+    "plt.ylabel(\"$x_2$\")\n",
+    "plt.title(\"Labels utilisés pour générer les données\")\n",
+    "plt.legend(prop={'size': 15})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clusters = cluster.KMeans(n_clusters = 3, random_state = 45).fit_predict(X)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(5, 5))\n",
+    "for i in [0, 1, 2]:\n",
+    "    plt.scatter(X[clusters == i, 0], X[clusters == i, 1], label = i)\n",
+    "plt.xlabel(\"$x_1$\")\n",
+    "plt.ylabel(\"$x_2$\")\n",
+    "plt.title(\"Cluster obtenus par K-Means\")\n",
+    "plt.legend(title = \"clusters\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Nous obtenons des clusters assez proches des vrais clusters. Peut-on mesurer la qualité de ce clustering?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Mesurer la similarité entre deux clusterings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn import metrics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Nous voulons mesurer à quel point le clustering obtenu par k-means est proche des vrais classes. Pour ce faire, nous utilisons le l'index de Rand. \n",
+    "Considérons deux partitionnements des données $\\mathcal{P}_1$ $\\mathcal{P}_2$, qui correspondent à deus clustering. Définissons le quantités\n",
+    "- $a$: nombre de paires de points qui sont dans le même cluster pour $\\mathcal{P}_1$ et pour $\\mathcal{P}_2$.\n",
+    "- $b$: nombre de paires de points qui sont dans des clusters différents pour $\\mathcal{P}_1$ et pour $\\mathcal{P}_2$.\n",
+    "- $c$: nombre de paires de points qui sont dans le même cluster pour $\\mathcal{P}_1$ et pour des clusters différents pour $\\mathcal{P}_2$.\n",
+    "- $d$: nombre de paires de points qui sont dans des clusters différents pour $\\mathcal{P}_1$ et dans le même cluster pour $\\mathcal{P}_2$.\n",
+    "On voit que $a + b$ est le nombre de pairs consistantes entre les deux partitions et $c + d$ représente le nombre de pairs inconsistantes entre les deux partitions.\n",
+    "\n",
+    "Nous définissons alors\n",
+    "$$R = \\frac{a+b}{a+b+c+d} = \\frac{a+b}{n\\choose{2}}.$$\n",
+    "\n",
+    "L'index de Rand est compris entre $0$ et $1$ et permet de mesurer la consistance entre deux clusterings. En pratique, nous comparerons le clustering utilisé par K-means aux vrais labels utilisées pour générer les données.\n",
+    "\n",
+    "Mais il ne s'agit pas d'apprentissage supervisé ! puisque ces labels n'ont pas été utilisés pour entraîner la méthode de clustering. Nous pouvons utiliser l'indice de Rand parce que nous savons qu'il y a trois vraies classes qui ont permis de générer les données. Mais dans les applications pratiques, le clustering n'est pas utilisé pour trouver des classes qui correspondent à des labels dont l'on disposerait (sinon, on utiliserait de la classification supervisée)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "metrics.rand_score(clusters, label)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "C'est un score élevé. L'index de Rand est plus faible pour le clustering des données penguins :"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"L'index de Rand des clusters de manchots est %.2f.\" % metrics.rand_score(y, y_pred))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "On peut aussi utiliser l'index de Rand ajusté ([https://scikit-learn.org/stable/modules/generated/sklearn.metrics.adjusted_rand_score.html](réference)), qui compense le fait que deux clusterings choisis aléatoirements n'ont pas un index de Rand nul."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"L'index de Rand ajusté des clusters de manchots est %.2f.\" % metrics.adjusted_rand_score(y, y_pred))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Choisir le nombre de cluster"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Nous allons utiliser un critère pour choisir le bon nombre de cluster. Nous allons utiliser le coefficient de silhouette ([https://scikit-learn.org/stable/modules/generated/sklearn.metrics.silhouette_score.html](référence))).\n",
+    "\n",
+    "Soit $a(\\boldsymbol{x})$ la distance moyenne intra-cluster pour le point $\\boldsymbol{x}$:\n",
+    "$$a(\\boldsymbol{x}) = \\frac{1}{|C_k| - 1} \\sum_{\\boldsymbol{x'}\\in C_k \\backslash \\boldsymbol{x}} ||\\boldsymbol{x} - \\boldsymbol{x'}||.$$ \n",
+    "Soit $b(\\boldsymbol{x})$ la distance moyenne au plus proche cluster:\n",
+    "$$b(\\boldsymbol{x}) = \\min_{l\\neq k} \\frac{1}{|C_k| - 1} \\sum_{\\boldsymbol{x'} \\in C_l} ||\\boldsymbol{x} - \\boldsymbol{x'}||.$$ \n",
+    "$a(\\boldsymbol{x})$ quantifie à quel point $\\boldsymbol{x}$ est bien intégré à son cluster et $b(\\boldsymbol{x})$ quantifie à quel point $\\boldsymbol{x}$ serait bien intégré à un autre cluster.\n",
+    "\n",
+    "Le coefficient de silhouette est défini par:\n",
+    "$$s(\\boldsymbol{x}) = \\frac{b(\\boldsymbol{x}) - a(\\boldsymbol{x})}{\\max(a(\\boldsymbol{x}), b(\\boldsymbol{x})}.$$\n",
+    "Il est compris entre $-1$ (si $\\boldsymbol{x}$ est très proche des points d'un autre cluster) et $1$ (si $\\boldsymbol{x}$ est très proche des points de son cluster).\n",
+    "\n",
+    "La somme $s = \\sum_{\\boldsymbol{x}} s(\\boldsymbol{x})$ des scores de silhouette donne un score global de la \"qualité\" du clustering."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Nous pouvons maintenant utiliser ce score pour comparer les clusterings obtenus avec K-means pour différents nombres de clusters:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y_pred2 = cluster.KMeans(n_clusters=2, random_state=34).fit_predict(X)\n",
+    "y_pred3 = cluster.KMeans(n_clusters=3, random_state=34).fit_predict(X)\n",
+    "y_pred4 = cluster.KMeans(n_clusters=4, random_state=34).fit_predict(X)\n",
+    "y_pred5 = cluster.KMeans(n_clusters=5, random_state=34).fit_predict(X)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize = (10, 10))\n",
+    "plt.subplot(221)\n",
+    "plt.scatter(X[:, 0], X[:, 1], \n",
+    "            c=y_pred2)\n",
+    "plt.title(\"k = 2, silhouette_score = %.2f\" % \\\n",
+    "          metrics.silhouette_score(X, y_pred2))\n",
+    "plt.xlabel(\"Longueur du bec (mm)\")\n",
+    "plt.ylabel(\"Hauteur du bec (mm)\")\n",
+    "plt.subplot(222)\n",
+    "plt.scatter(X[:, 0], X[:, 1], \n",
+    "            c=y_pred3)\n",
+    "plt.title(\"k = 2, silhouette_score = %.2f\" % \\\n",
+    "          metrics.silhouette_score(X, y_pred3))\n",
+    "plt.xlabel(\"Longueur du bec (mm)\")\n",
+    "plt.ylabel(\"Hauteur du bec (mm)\")\n",
+    "\n",
+    "plt.subplot(223)\n",
+    "plt.scatter(X[:, 0], X[:, 1], \n",
+    "            c=y_pred4)\n",
+    "plt.title(\"k = 2, silhouette_score = %.2f\" % \\\n",
+    "          metrics.silhouette_score(X, y_pred4))\n",
+    "plt.xlabel(\"Longueur du bec (mm)\")\n",
+    "plt.ylabel(\"Hauteur du bec (mm)\")\n",
+    "\n",
+    "plt.subplot(224)\n",
+    "plt.scatter(X[:, 0], X[:, 1], \n",
+    "            c=y_pred5)\n",
+    "plt.title(\"k = 2, silhouette_score = %.2f\" % \\\n",
+    "          metrics.silhouette_score(X, y_pred5))\n",
+    "plt.xlabel(\"Longueur du bec (mm)\")\n",
+    "plt.ylabel(\"Hauteur du bec (mm)\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "En utilisant la métrique du score de silhouette, **il est préférable de choisir 3 clusters**. C'est la *bonne* réponse, puisqu'on a utilité 3 gaussiennes pour générer les données.\n",
+    "\n",
+    "Pour aller plus loin, on peut vouloir représenter la *distribution* des silhouettes de chaque cluster, au lieu d'uniquement calculer leurs moyennes. Nous utilisons pour cela la fonction `silhouette_samples` :"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get input values\n",
+    "X = df_blobs.loc[:, [\"x1\", \"x2\"]].values\n",
+    "\n",
+    "# one silhouette plot for different numbers of clusters.\n",
+    "for n_clusters in [2, 3, 4, 9]:\n",
+    "    \n",
+    "    # create a subplot with 1 row and 2 columns\n",
+    "    fig, (ax1, ax2) = plt.subplots(1, 2)\n",
+    "    fig.set_size_inches(10, 4)\n",
+    "    \n",
+    "    # demarcate silhouette plots of individual clusters by inserting blanck space\n",
+    "    ax1.set_ylim([0, len(X) + (n_clusters + 1) * 10])\n",
+    "\n",
+    "    # K-means clustering\n",
+    "    kmean = cluster.KMeans(\n",
+    "        n_clusters=n_clusters, init='k-means++', \n",
+    "        n_init=10, max_iter=300, tol=0.0001, \n",
+    "        verbose=0, random_state=13, \n",
+    "        algorithm='auto')\n",
+    "    cluster_labels = kmean.fit_predict(X)\n",
+    "\n",
+    "    # compute average silhouette score\n",
+    "    score = metrics.silhouette_score(X, cluster_labels)\n",
+    "\n",
+    "    # compute silhouette scores for each sample\n",
+    "    sample_silhouette_values = metrics.silhouette_samples(X, cluster_labels)\n",
+    "\n",
+    "    # plot silhouette scores for each sample\n",
+    "    y_lower = 10\n",
+    "    for i in range(n_clusters):\n",
+    "        \n",
+    "        # aggregate the silhouette scores for samples belonging to cluster i and sort them\n",
+    "        ith_cluster_silhouette_values = sample_silhouette_values[cluster_labels == i]\n",
+    "        ith_cluster_silhouette_values.sort()\n",
+    "        size_cluster_i = ith_cluster_silhouette_values.shape[0]\n",
+    "        y_upper = y_lower + size_cluster_i\n",
+    "        color = cm.nipy_spectral(float(i) / n_clusters)\n",
+    "        ax1.fill_betweenx(np.arange(y_lower, y_upper),\n",
+    "                          0, ith_cluster_silhouette_values,\n",
+    "                          facecolor=color, edgecolor=color, alpha=0.7)\n",
+    "\n",
+    "        # label the silhouette plots with their cluster numbers at the middle\n",
+    "        ax1.text(-0.05, y_lower + 0.5 * size_cluster_i, str(i))\n",
+    "\n",
+    "        # compute the new y_lower for next plot\n",
+    "        y_lower = y_upper + 10  # 10 for the 0 samples\n",
+    "\n",
+    "    # axis labels and title\n",
+    "    ax1.set_title(\"Average silhouette coefficient: {0:0.3f}\".format(score), fontsize=10)\n",
+    "    ax1.set_xlabel(\"Silhouette coefficient values\", fontsize=15)\n",
+    "    ax1.set_ylabel(\"Cluster label\", fontsize=15)\n",
+    "\n",
+    "    # draw a vertical line for average silhouette score of all the values\n",
+    "    ax1.axvline(x=score, color=\"red\", linestyle=\"--\")\n",
+    "\n",
+    "    # clear the yaxis labels / ticks\n",
+    "    ax1.set_yticks([])  \n",
+    "    ax1.set_xticks([-0.1, 0, 0.2, 0.4, 0.6, 0.8, 1])\n",
+    "\n",
+    "    # 2nd plot showing the actual clusters formed\n",
+    "    colors = cm.nipy_spectral(cluster_labels.astype(float) / n_clusters)\n",
+    "    ax2.scatter(X[:, 0], X[:, 1], \n",
+    "                marker='o', s=30, alpha=0.8, c=colors, edgecolor='k')    \n",
+    "    \n",
+    "    # draw white circles at cluster centers\n",
+    "    centers = kmean.cluster_centers_\n",
+    "    ax2.scatter(centers[:, 0], centers[:, 1], marker='o',\n",
+    "                c=\"white\", alpha=1, s=200, edgecolor='k')\n",
+    "\n",
+    "    for i, c in enumerate(centers):\n",
+    "        ax2.scatter(c[0], c[1], marker='$%d$' % i, alpha=1,\n",
+    "                    s=50, edgecolor='k')\n",
+    "        \n",
+    "    # axis labels and title\n",
+    "    ax2.set_title(\"Number of clusters: {0}\".format(n_clusters), fontsize=15)\n",
+    "    ax2.set_xlabel(\"X1\", fontsize=10)\n",
+    "    ax2.set_ylabel(\"X2\", fontsize=10)\n",
+    "\n",
+    "    # main title\n",
+    "    plt.suptitle((\"Silhouette analysis for K-means clustering on sample data \"\n",
+    "                  \"with n_clusters = {0}\".format(n_clusters)),\n",
+    "                 fontsize=10, fontweight='bold')\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Nous voyons que la distribution des score de silhouette dans chaque cluster représente bien à quel point le cluster est \"clairement identifié\" comparé aux autre clusters. \n",
+    "\n",
+    "Lorsque beaucoup de points dans un cluster a un coefficient de silhouette élevé, la distribution de coefficients est concentrée autour d'une valeur élevée, comme c'est le cas avec $k = 2$ et $k = 3$ clusters (correspondant aux figures des deux lignes du haut).\n",
+    "\n",
+    "En revanche, lorsqu'un clusters a beaucoup de coefficients de silhouette autour de valeurs faible, le discribution des coefficients est presque uniforme entre $0$ et une valeur faiblement élevée ($\\sim 0.5$), comme c'est le cas avec $k=4$ et $k = 9$ clusters (correspondant aux figures des deux lignes du bas)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Implémentation de K-means en python"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Quelques fonctions utiles:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialiser les clusters aléatoirement\n",
+    "def initialize_clusters(points, k, random_state = None):\n",
+    "    \"\"\"Initializes clusters as k randomly selected points from points.\"\"\"\n",
+    "    if random_state is not None:\n",
+    "        numpy.random.seed(random_state)\n",
+    "    return points[np.random.randint(points.shape[0], size=k)]\n",
+    "    \n",
+    "# Calcul des distances entre points de centroides\n",
+    "def get_distances(centroid, points):\n",
+    "    \"\"\"Returns the distance the centroid is from each data point in points.\"\"\"\n",
+    "    return np.linalg.norm(points - centroid, axis=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Implémentation:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "k = 3\n",
+    "max_iter = 50\n",
+    "\n",
+    "# Initialize our centroids by picking random data points\n",
+    "centroids = initialize_clusters(X, k, random_state=17)\n",
+    "\n",
+    "# Initialize the vectors in which we will store the\n",
+    "# assigned classes of each data point and the\n",
+    "# calculated distances from each centroid\n",
+    "classes = np.zeros(X.shape[0], dtype=np.float64)\n",
+    "distances = np.zeros([X.shape[0], k], dtype=np.float64)\n",
+    "\n",
+    "## Define oject to keep the kmeans iterations results in memory\n",
+    "classes_all = np.zeros((X.shape[0], max_iter), dtype = np.int16)\n",
+    "centroids_all = np.zeros((centroids.shape[0], centroids.shape[1], max_iter))\n",
+    "\n",
+    "# Loop for the maximum number of iterations\n",
+    "for i in range(max_iter):\n",
+    "    \n",
+    "    # Assign all points to the nearest centroid\n",
+    "    for j, c in enumerate(centroids):\n",
+    "        distances[:, j] = get_distances(c, X)\n",
+    "        \n",
+    "    # Determine class membership of each point\n",
+    "    # by picking the closest centroid\n",
+    "    classes = np.argmin(distances, axis=1)\n",
+    "    classes_all[:, i] = classes\n",
+    "    \n",
+    "    # Update centroid location using the newly\n",
+    "    # assigned data point classes\n",
+    "    for c in range(k):\n",
+    "        centroids[c] = np.mean(X[classes == c], 0)\n",
+    "    centroids_all[:, :, i] = centroids"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Nous pouvons afficher le résultat:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for label in [0, 1, 2]:\n",
+    "    plt.scatter(X[classes == label,0], X[classes == label, 1], alpha=0.5)\n",
+    "plt.scatter(centroids[:,0], centroids[:,1], color=['blue', 'darkred', 'green'], marker='o', lw=2)\n",
+    "plt.xlabel('$x_1$')\n",
+    "plt.ylabel('$x_2$')\n",
+    "plt.title(\"Clustering obtained by scikit-learn\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Nous pouvons aussi représenter les différentes étapes de K-means:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize = (8, 8))\n",
+    "for ind in range(0, 6):\n",
+    "    plt.subplot(3, 2, ind + 1)\n",
+    "    for label in [0, 1, 2]:\n",
+    "        plt.scatter(X[classes_all[:, ind] == label,0], X[classes_all[:, ind] == label, 1], alpha=0.5)\n",
+    "    \n",
+    "    plt.scatter(centroids_all[:,0 , ind], centroids_all[:, 1, ind],\\\n",
+    "                color=['blue', 'darkred', 'green'], marker='o', lw=2)\n",
+    "    plt.xlabel(\"$x_1$\")\n",
+    "    plt.ylabel(\"$x_2$\")\n",
+    "    plt.tight_layout()\n",
+    "    plt.title(\"Iteration #\" + str(ind))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Pour aller plus loin"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "1. Sur le jeu de données `penguins` K-means ne parvenait pas à séparer les trois espèces. \n",
+    "\n",
+    "- Utilisez l'analyse de score de silhouette pour vérifier que k = 3 est le nombre \"optimal\" de clusters\n",
+    "- Utilisez K-means en ajoutant la variable \"flipper_length_mm\" aux deux variables \"bill_length_mm\" et \"bill_depth_mm\". Utilisez l'index de Rand pour estimer si le clustering obtenu est plus proche des trois espèces de manchots.\n",
+    "\n",
+    "2. D'autres méthodes de clustering sont présentées [https://scikit-learn.org/stable/modules/clustering.html#overview-of-clustering-methods](ici).\n",
+    "\n",
+    "- En observant les résultats des différentes méthodes sur le jeu de données à la première rangée, quelles méthodes semblent ne pas faire l'hypothèse que les clusters sont convexes ?\n",
+    "- En observant les résultats des différentes méthodes sur la quatrième rangée, quelles méthodes semblent ne pas faire l'hypothèse que les clusters sont isotropes ?"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Added notebook on clustering, experimenting with k-means and the penguins dataset.
1. Run on penguins and on simulated "blob" dataset
2. Use Rand Index and evaluate "quality" of clustering
3. Use silhouette score to explore the "best" number of clusters

Remark: I used the simulated dataset through most of the notebook because the penguins dataset does not illustrate k-means well (the three species are not clear clusters).



Pending question: the last section "Pour aller plus loin" is somewhat vague. We could include:
- Variants and extensions of K-means (k-medians, k-medioids)
- Examples of clustering in datasets of higher dimension (e.g. [hand-written digits dataset](https://scikit-learn.org/stable/auto_examples/cluster/plot_kmeans_digits.html#a-demo-of-k-means-clustering-on-the-handwritten-digits-data)).